### PR TITLE
fix: Add result path to custom flow

### DIFF
--- a/custom-tool-flow-definition/client.py
+++ b/custom-tool-flow-definition/client.py
@@ -18,6 +18,7 @@ class HelloTool(GladierBaseTool):
                     "sleep_time.$": "$.input.sleep_time",
                 },
                 "End": True,
+                "ResultPath": "$.Hello"
             }
         },
     }


### PR DESCRIPTION
This doesn't fix anything wrong with the flow itself, but I found out that NOT specifying a result path will overwrite EVERYTHING on the flow's volitile state. So if any next steps rely on it, which they almost always do for Gladier, those next steps will suddenly fail.

So if anyone copies this code and wonders why multiple states don't work, this will fix that.